### PR TITLE
Configure auto-registered agent environments.

### DIFF
--- a/gocd-agent/Dockerfile
+++ b/gocd-agent/Dockerfile
@@ -1,0 +1,1 @@
+../Dockerfile.gocd-agent

--- a/gocd-agent/Dockerfile
+++ b/gocd-agent/Dockerfile
@@ -1,1 +1,0 @@
-../Dockerfile.gocd-agent

--- a/gocd-agent/go-agent-start.sh
+++ b/gocd-agent/go-agent-start.sh
@@ -14,5 +14,6 @@ mkdir -p /var/lib/go-agent/config
 AGENT_KEY="${AGENT_KEY:-123456789abcdef}"
 echo "agent.auto.register.key=$AGENT_KEY" >/var/lib/go-agent/config/autoregister.properties
 if [ -n "$AGENT_RESOURCES" ]; then echo "agent.auto.register.resources=$AGENT_RESOURCES" >>/var/lib/go-agent/config/autoregister.properties; fi
+if [ -n "$AGENT_ENVIRONMENTS" ]; then echo "agent.auto.register.environments=$AGENT_ENVIRONMENTS" >>/var/lib/go-agent/config/autoregister.properties; fi
 
 /sbin/setuser go /etc/init.d/go-agent start


### PR DESCRIPTION
Add ability to configure agent.auto.register.environments in /var/lib/go-agent/config/autoregister.properties with an AGENT_ENVIRONMENTS environment variable.
