### PR TITLE
Upgrade to Version 15.2

### DIFF
--- a/Dockerfile.gocd-agent
+++ b/Dockerfile.gocd-agent
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y -q unzip openjdk-7-jre-headless git
 RUN mkdir /etc/service/go-agent
 ADD gocd-agent/go-agent-start.sh /etc/service/go-agent/run
 
-ADD http://download.go.cd/gocd-deb/go-agent-15.1.0-1863.deb /tmp/go-agent.deb
+ADD http://download.go.cd/gocd-deb/go-agent-15.2.0-2248.deb /tmp/go-agent.deb
 
 WORKDIR /tmp
 RUN dpkg -i /tmp/go-agent.deb

--- a/Dockerfile.gocd-dev
+++ b/Dockerfile.gocd-dev
@@ -15,8 +15,8 @@ RUN mkdir /etc/service/go-agent
 ADD gocd-dev/go-common-scripts.sh /etc/service/go-agent/go-common-scripts.sh
 ADD gocd-dev/go-agent-start.sh /etc/service/go-agent/run
 
-ADD http://download.go.cd/gocd-deb/go-server-15.1.0-1863.deb /tmp/go-server.deb
-ADD http://download.go.cd/gocd-deb/go-agent-15.1.0-1863.deb /tmp/go-agent.deb
+ADD http://download.go.cd/gocd-deb/go-server-15.2.0-2248.deb /tmp/go-server.deb
+ADD http://download.go.cd/gocd-deb/go-agent-15.2.0-2248.deb /tmp/go-agent.deb
 
 WORKDIR /tmp
 RUN dpkg -i /tmp/go-server.deb

--- a/Dockerfile.gocd-server
+++ b/Dockerfile.gocd-server
@@ -9,7 +9,7 @@ RUN mkdir /etc/service/go-server
 ADD gocd-server/go-common-scripts.sh /etc/service/go-server/go-common-scripts.sh
 ADD gocd-server/go-server-start.sh /etc/service/go-server/run
 
-ADD http://download.go.cd/gocd-deb/go-server-15.1.0-1863.deb /tmp/go-server.deb
+ADD http://download.go.cd/gocd-deb/go-server-15.2.0-2248.deb /tmp/go-server.deb
 
 RUN ["groupadd", "-r", "go"]
 RUN ["useradd", "-r", "-c", "Go User", "-g", "go", "-d", "/var/go", "-m", "-s", "/bin/bash", "go"]


### PR DESCRIPTION
The current supported release for Go is 15.2.0-2248. Since the release of 15.2, several plugins have been updated for the version. This PR updates the Dockerfiles to work with 15.2 instead of 15.1.
