### PR TITLE
Improved Dockerfile.gocd-agent

### DIFF
--- a/Dockerfile.gocd-agent
+++ b/Dockerfile.gocd-agent
@@ -19,7 +19,7 @@ RUN rm -f /etc/default/go-agent
 
 USER go
 
-ENV GO_SERVER=localhost
+ENV GO_SERVER=go-server
 ENV GO_SERVER_PORT=8153
 ENV AGENT_WORK_DIR=/var/lib/go-agent
 ENV AGENT_KEY=123456789abcdef

--- a/Dockerfile.gocd-agent
+++ b/Dockerfile.gocd-agent
@@ -2,10 +2,7 @@
 FROM java:openjdk-7-jre
 MAINTAINER Aravind SV <arvind.sv@gmail.com>
 
-RUN useradd go
-
-RUN mkdir -p /var/run/go-agent && \
-  chown -R go /var/run/go-agent
+RUN mkdir -p /var/run/go-agent
 
 WORKDIR /tmp
 
@@ -16,8 +13,6 @@ RUN curl -L http://download.go.cd/gocd-deb/go-agent-15.2.0-2248.deb > /tmp/go-ag
 
 RUN mkdir -p /var/lib/go-agent/config
 RUN rm -f /etc/default/go-agent
-
-USER go
 
 ENV GO_SERVER=go-server
 ENV GO_SERVER_PORT=8153

--- a/Dockerfile.gocd-agent
+++ b/Dockerfile.gocd-agent
@@ -1,19 +1,33 @@
 # Build using: docker build -f Dockerfile.gocd-agent -t gocd-agent .
-FROM phusion/baseimage:0.9.16
+FROM java:openjdk-7-jre
 MAINTAINER Aravind SV <arvind.sv@gmail.com>
 
-RUN rm -rf /etc/service/sshd /etc/my_init.d/00_regen_ssh_host_keys.sh
-RUN apt-get update && apt-get install -y -q unzip openjdk-7-jre-headless git
+RUN useradd go
 
-RUN mkdir /etc/service/go-agent
-ADD gocd-agent/go-agent-start.sh /etc/service/go-agent/run
-
-ADD http://download.go.cd/gocd-deb/go-agent-15.2.0-2248.deb /tmp/go-agent.deb
+RUN mkdir -p /var/run/go-agent && \
+  chown -R go /var/run/go-agent
 
 WORKDIR /tmp
-RUN dpkg -i /tmp/go-agent.deb
-RUN sed -i 's/DAEMON=Y/DAEMON=N/' /etc/default/go-agent
 
-RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN curl -L http://download.go.cd/gocd-deb/go-agent-15.2.0-2248.deb > /tmp/go-agent.deb && \
+  dpkg -i /tmp/go-agent.deb && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-CMD ["/sbin/my_init"]
+RUN mkdir -p /var/lib/go-agent/config
+RUN rm -f /etc/default/go-agent
+
+USER go
+
+ENV GO_SERVER=localhost
+ENV GO_SERVER_PORT=8153
+ENV AGENT_WORK_DIR=/var/lib/go-agent
+ENV AGENT_KEY=123456789abcdef
+ENV DAEMON=N
+ENV VNC=N
+
+ENV JAVA_HOME=/usr/lib/jvm/java-7-openjdk-amd64
+
+ADD gocd-agent/go-agent-start.sh /usr/local/bin/go-agent
+
+CMD ["/usr/local/bin/go-agent"]

--- a/gocd-agent/go-agent-start.sh
+++ b/gocd-agent/go-agent-start.sh
@@ -6,14 +6,10 @@ COLOR_START="[01;34m"
 COLOR_END="[00m"
 
 echo -e "${COLOR_START}Starting Go Agent to connect to server $GO_SERVER ...${COLOR_END}"
-sed -i -e 's/GO_SERVER=.*/GO_SERVER='$GO_SERVER'/' /etc/default/go-agent
 
-mkdir -p /var/lib/go-agent/config
-/bin/rm -f /var/lib/go-agent/config/autoregister.properties
-
-AGENT_KEY="${AGENT_KEY:-123456789abcdef}"
 echo "agent.auto.register.key=$AGENT_KEY" >/var/lib/go-agent/config/autoregister.properties
+
 if [ -n "$AGENT_RESOURCES" ]; then echo "agent.auto.register.resources=$AGENT_RESOURCES" >>/var/lib/go-agent/config/autoregister.properties; fi
 if [ -n "$AGENT_ENVIRONMENTS" ]; then echo "agent.auto.register.environments=$AGENT_ENVIRONMENTS" >>/var/lib/go-agent/config/autoregister.properties; fi
 
-/sbin/setuser go /etc/init.d/go-agent start
+exec /usr/share/go-agent/agent.sh


### PR DESCRIPTION
There is no need to use init scripts to start the agent service within a docker
container. This new image just runs the go agent directly. This solves a problem where the container didn't respond properly to signals like SIGINT/SIGTERM.

This image is based off of the official Java 7 headless JRE, which helps limit
image size. It's now 339MB vs 433MB.

This PR can also help fix #11
