### PR TITLE
Remove config dirs from VOLUME

### DIFF
--- a/Dockerfile.gocd-server
+++ b/Dockerfile.gocd-server
@@ -15,7 +15,7 @@ RUN ["groupadd", "-r", "go"]
 RUN ["useradd", "-r", "-c", "Go User", "-g", "go", "-d", "/var/go", "-m", "-s", "/bin/bash", "go"]
 RUN ["mkdir", "-p", "/var/lib/go-server/addons", "/var/log/go-server", "/etc/go", "/go-addons"]
 RUN ["chown", "-R", "go:go", "/var/lib/go-server", "/var/log/go-server", "/etc/go", "/go-addons", "/var/go"]
-VOLUME ["/var/lib/go-server", "/var/log/go-server", "/etc/go", "/go-addons", "/var/go"]
+VOLUME ["/var/lib/go-server", "/var/log/go-server", "/go-addons"]
 
 WORKDIR /tmp
 RUN dpkg -i --debug=10 /tmp/go-server.deb


### PR DESCRIPTION
Per docker issue 3639 Dockerfile that constitute a base image should not
set config dirs w/ VOLUME as downstream Dockerfile can not modify w/ RUN
instructions.

https://github.com/docker/docker/issues/3639

Issue #8
