### PR TITLE
RFC: Move away from phusion/baseimage

### DIFF
--- a/Dockerfile.gocd-agent
+++ b/Dockerfile.gocd-agent
@@ -1,19 +1,19 @@
 # Build using: docker build -f Dockerfile.gocd-agent -t gocd-agent .
-FROM phusion/baseimage:0.9.18
+FROM java:openjdk-7-jre
 MAINTAINER Aravind SV <arvind.sv@gmail.com>
 
-RUN rm -rf /etc/service/sshd /etc/my_init.d/00_regen_ssh_host_keys.sh
-RUN apt-get update && apt-get install -y -q unzip openjdk-7-jre-headless git
-
-RUN mkdir /etc/service/go-agent
-ADD gocd-agent/go-agent-start.sh /etc/service/go-agent/run
-
-ADD https://download.go.cd/binaries/16.2.1-3027/deb/go-agent-16.2.1-3027.deb /tmp/go-agent.deb
-
 WORKDIR /tmp
-RUN dpkg -i /tmp/go-agent.deb
-RUN sed -i 's/DAEMON=Y/DAEMON=N/' /etc/default/go-agent
 
-RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+ENV GOCD_VERSION=16.2.1-3027
 
-CMD ["/sbin/my_init"]
+RUN curl -L https://download.go.cd/binaries/${GOCD_VERSION}/deb/go-agent-${GOCD_VERSION}.deb >/tmp/go-agent.deb && \
+ dpkg -i /tmp/go-agent.deb && \
+ curl -L -O https://github.com/Yelp/dumb-init/releases/download/v1.0.0/dumb-init_1.0.0_amd64.deb && \
+ dpkg -i /tmp/dumb-init_* && \
+ apt-get update && apt-get install sudo && \
+ apt-get clean && \
+ rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ADD gocd-agent/go-agent-start.sh /usr/local/bin/go-agent
+
+CMD ["dumb-init", "/usr/local/bin/go-agent"]

--- a/Dockerfile.gocd-agent
+++ b/Dockerfile.gocd-agent
@@ -5,14 +5,15 @@ MAINTAINER Aravind SV <arvind.sv@gmail.com>
 WORKDIR /tmp
 
 ENV GOCD_VERSION=16.2.1-3027
+ENV GOCD_AGENT_SHA1=d72f8e314499e69dfd56741a866f08cfa695def2
+ENV GOCD_AGENT_URL=https://download.go.cd/binaries/${GOCD_VERSION}/deb/go-agent-${GOCD_VERSION}.deb
 
-RUN curl -L https://download.go.cd/binaries/${GOCD_VERSION}/deb/go-agent-${GOCD_VERSION}.deb >/tmp/go-agent.deb && \
- dpkg -i /tmp/go-agent.deb && \
- curl -L -O https://github.com/Yelp/dumb-init/releases/download/v1.0.0/dumb-init_1.0.0_amd64.deb && \
- dpkg -i /tmp/dumb-init_* && \
- apt-get update && apt-get install sudo && \
- apt-get clean && \
- rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN curl -fSL $GOCD_AGENT_URL >go-agent.deb && \
+  echo "$GOCD_AGENT_SHA1 go-agent.deb" | sha1sum -c - && \
+  dpkg -i go-agent.deb && \
+  curl -L -O https://github.com/Yelp/dumb-init/releases/download/v1.0.0/dumb-init_1.0.0_amd64.deb && \
+  dpkg -i /tmp/dumb-init_* && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ADD gocd-agent/go-agent-start.sh /usr/local/bin/go-agent
 

--- a/gocd-agent/go-agent-start.sh
+++ b/gocd-agent/go-agent-start.sh
@@ -1,19 +1,28 @@
 #!/bin/bash
 
 GO_SERVER=${GO_SERVER:-go-server}
+AGENT_KEY=${AGENT_KEY:-123456789abcdef}
+DAEMON=${DAEMON:-N}
 
 COLOR_START="[01;34m"
 COLOR_END="[00m"
 
+mkdir -p /var/lib/go-agent/config /var/run/go-agent /var/log/go-agent
+chown -R go:go /var/lib/go-agent/config /var/run/go-agent /var/log/go-agent
+
+autoregister_file=/var/lib/go-agent/config/autoregister.properties
+logfiles=(go-agent-bootstrapper.out.log go-agent-launcher.log go-agent-stderr.log go-agent-stdout.log go-agent.log)
+
 echo -e "${COLOR_START}Starting Go Agent to connect to server $GO_SERVER ...${COLOR_END}"
-sed -i -e 's/GO_SERVER=.*/GO_SERVER='$GO_SERVER'/' /etc/default/go-agent
+sed -i \
+    -e 's/GO_SERVER=.*/GO_SERVER='$GO_SERVER'/' \
+    -e 's/DAEMON=.*/DAEMON='$DAEMON'/' \
+    /etc/default/go-agent
 
-mkdir -p /var/lib/go-agent/config
-/bin/rm -f /var/lib/go-agent/config/autoregister.properties
+echo "agent.auto.register.key=$AGENT_KEY" >$autoregister_file
+if [ -n "$AGENT_RESOURCES" ]; then echo "agent.auto.register.resources=$AGENT_RESOURCES" >>$autoregister_file; fi
+if [ -n "$AGENT_ENVIRONMENTS" ]; then echo "agent.auto.register.environments=$AGENT_ENVIRONMENTS" >>$autoregister_file; fi
+chown go:go $autoregister_file
 
-AGENT_KEY="${AGENT_KEY:-123456789abcdef}"
-echo "agent.auto.register.key=$AGENT_KEY" >/var/lib/go-agent/config/autoregister.properties
-if [ -n "$AGENT_RESOURCES" ]; then echo "agent.auto.register.resources=$AGENT_RESOURCES" >>/var/lib/go-agent/config/autoregister.properties; fi
-if [ -n "$AGENT_ENVIRONMENTS" ]; then echo "agent.auto.register.environments=$AGENT_ENVIRONMENTS" >>/var/lib/go-agent/config/autoregister.properties; fi
-
-/sbin/setuser go /etc/init.d/go-agent start
+(cd /var/log/go-agent; touch "${logfiles[@]}"; chown go:go "${logfiles[@]}"; tail -F -v "${logfiles[@]}" & disown)
+exec sudo -u go -i /usr/share/go-agent/agent.sh

--- a/gocd-agent/go-agent-start.sh
+++ b/gocd-agent/go-agent-start.sh
@@ -1,28 +1,25 @@
 #!/bin/bash
 
-GO_SERVER=${GO_SERVER:-go-server}
 AGENT_KEY=${AGENT_KEY:-123456789abcdef}
-DAEMON=${DAEMON:-N}
 
-COLOR_START="[01;34m"
-COLOR_END="[00m"
+export GO_SERVER=${GO_SERVER:-go-server}
+export GO_SERVER_PORT=8153
+export DAEMON=${DAEMON:-N}
+export AGENT_WORK_DIR=/var/lib/go-agent
+export JAVA_HOME=/usr/lib/jvm/java-7-openjdk-amd64/jre
 
 mkdir -p /var/lib/go-agent/config /var/run/go-agent /var/log/go-agent
 chown -R go:go /var/lib/go-agent/config /var/run/go-agent /var/log/go-agent
 
+rm -f /etc/default/go-agent
+
 autoregister_file=/var/lib/go-agent/config/autoregister.properties
-logfiles=(go-agent-bootstrapper.out.log go-agent-launcher.log go-agent-stderr.log go-agent-stdout.log go-agent.log)
-
-echo -e "${COLOR_START}Starting Go Agent to connect to server $GO_SERVER ...${COLOR_END}"
-sed -i \
-    -e 's/GO_SERVER=.*/GO_SERVER='$GO_SERVER'/' \
-    -e 's/DAEMON=.*/DAEMON='$DAEMON'/' \
-    /etc/default/go-agent
-
 echo "agent.auto.register.key=$AGENT_KEY" >$autoregister_file
 if [ -n "$AGENT_RESOURCES" ]; then echo "agent.auto.register.resources=$AGENT_RESOURCES" >>$autoregister_file; fi
 if [ -n "$AGENT_ENVIRONMENTS" ]; then echo "agent.auto.register.environments=$AGENT_ENVIRONMENTS" >>$autoregister_file; fi
 chown go:go $autoregister_file
 
+logfiles=(go-agent-bootstrapper.out.log go-agent-launcher.log go-agent-stderr.log go-agent-stdout.log go-agent.log)
 (cd /var/log/go-agent; touch "${logfiles[@]}"; chown go:go "${logfiles[@]}"; tail -F -v "${logfiles[@]}" & disown)
-exec sudo -u go -i /usr/share/go-agent/agent.sh
+
+exec /usr/share/go-agent/agent.sh


### PR DESCRIPTION
This is an attempt to move away from phusion/baseimage. Only for the gocd-agent image right now.
- phusion/baseimage is not being updated quick enough, to take care of security vulnerabilities for instance.

Also in this commit:
- Use dumb_init instead to provide a proper init process, to propagate signals and take over zombies.
- Use sudo to lauch the agent process, since it propagates signals properly, unlike su and bash.
- tail all logs of the agent
- Use openjdk-7-jre baseimage directly. Still not ideal (it uses an old debian baseimage), but better than before.

The idea was to also get signal propagation correct. Meaning, we should be able to do a:

`docker kill -s 3 container-id`

and it should send SIGQUIT (3) to the agent process, and make it dump stack traces as a normal java process would. Also, sending a `docker kill -s 15 container-id` should gracefully kill the agent and then the container.

I started from the changes made by @dkastner in #13 and changed from there. Would love any feedback.
