### PR TITLE
#32 Scripts for automating the docker upload

### DIFF
--- a/Dockerfile.gocd-agent
+++ b/Dockerfile.gocd-agent
@@ -1,14 +1,15 @@
-# Build using: docker build -f Dockerfile.gocd-agent -t gocd-agent .
-FROM phusion/baseimage:0.9.18
-MAINTAINER Aravind SV <arvind.sv@gmail.com>
+# Build using: docker build --build-arg GO_VERSION=16.x.x-xxxx -f Dockerfile.gocd-agent -t gocd-agent .
+FROM gocd/gocd-base
+MAINTAINER GoCD <go-cd-dev@googlegroups.com>
 
-RUN rm -rf /etc/service/sshd /etc/my_init.d/00_regen_ssh_host_keys.sh
-RUN apt-get update && apt-get install -y -q unzip openjdk-7-jre-headless git mercurial subversion
+ARG GO_VERSION
+
+RUN apt-get update
 
 RUN mkdir /etc/service/go-agent
 ADD gocd-agent/go-agent-start.sh /etc/service/go-agent/run
 
-ADD https://download.go.cd/binaries/16.3.0-3183/deb/go-agent-16.3.0-3183.deb /tmp/go-agent.deb
+ADD https://download.go.cd/binaries/${GO_VERSION}/deb/go-agent-${GO_VERSION}.deb /tmp/go-agent.deb
 
 WORKDIR /tmp
 RUN dpkg -i /tmp/go-agent.deb

--- a/Dockerfile.gocd-base
+++ b/Dockerfile.gocd-base
@@ -1,0 +1,8 @@
+# Build using: docker build -f Dockerfile.gocd-base -t gocd-base .
+FROM phusion/baseimage:0.9.18
+MAINTAINER GoCD <go-cd-dev@googlegroups.com>
+
+RUN rm -rf /etc/service/sshd /etc/my_init.d/00_regen_ssh_host_keys.sh
+RUN apt-get update && apt-get install -y -q unzip openjdk-7-jre-headless git mercurial subversion
+
+CMD ["/sbin/my_init"]

--- a/Dockerfile.gocd-build-installer
+++ b/Dockerfile.gocd-build-installer
@@ -1,6 +1,6 @@
 # Build using: docker build -f Dockerfile.gocd-build-installer -t gocd-build-installer .
 FROM phusion/baseimage:0.9.16
-MAINTAINER Aravind SV <arvind.sv@gmail.com>
+MAINTAINER GoCD <go-cd-dev@googlegroups.com>
 
 RUN rm -rf /etc/service/sshd /etc/my_init.d/00_regen_ssh_host_keys.sh
 RUN apt-get update && apt-get install -y -q fakeroot git maven nsis openjdk-7-jdk rpm unzip zip

--- a/Dockerfile.gocd-dev
+++ b/Dockerfile.gocd-dev
@@ -1,9 +1,10 @@
-# Build using: docker build -f Dockerfile.gocd-dev -t gocd-dev .
-FROM phusion/baseimage:0.9.18
-MAINTAINER Aravind SV <arvind.sv@gmail.com>
+# Build using: docker build --build-arg GO_VERSION=16.x.x-xxxx -f Dockerfile.gocd-dev -t gocd-dev .
+FROM gocd/gocd-base
+MAINTAINER GoCD <go-cd-dev@googlegroups.com>
 
-RUN rm -rf /etc/service/sshd /etc/my_init.d/00_regen_ssh_host_keys.sh
-RUN apt-get update && apt-get install -y -q unzip openjdk-7-jre-headless git mercurial subversion
+ARG GO_VERSION
+
+RUN apt-get update
 
 RUN mkdir /etc/service/go-server
 ADD gocd-dev/go-common-scripts.sh /etc/service/go-server/go-common-scripts.sh
@@ -13,8 +14,8 @@ RUN mkdir /etc/service/go-agent
 ADD gocd-dev/go-common-scripts.sh /etc/service/go-agent/go-common-scripts.sh
 ADD gocd-dev/go-agent-start.sh /etc/service/go-agent/run
 
-ADD https://download.go.cd/binaries/16.3.0-3183/deb/go-server-16.3.0-3183.deb /tmp/go-server.deb
-ADD https://download.go.cd/binaries/16.3.0-3183/deb/go-agent-16.3.0-3183.deb /tmp/go-agent.deb
+ADD https://download.go.cd/binaries/${GO_VERSION}/deb/go-server-${GO_VERSION}.deb /tmp/go-server.deb
+ADD https://download.go.cd/binaries/${GO_VERSION}/deb/go-agent-${GO_VERSION}.deb /tmp/go-agent.deb
 
 WORKDIR /tmp
 RUN dpkg -i /tmp/go-server.deb

--- a/Dockerfile.gocd-server
+++ b/Dockerfile.gocd-server
@@ -1,15 +1,15 @@
-# Build using: docker build -f Dockerfile.gocd-server -t gocd-server .
-FROM phusion/baseimage:0.9.18
-MAINTAINER Aravind SV <arvind.sv@gmail.com>
+# Build using: docker build --build-arg GO_VERSION=16.x.x-xxxx -f Dockerfile.gocd-server -t gocd-server .
+FROM gocd/gocd-base
+MAINTAINER GoCD <go-cd-dev@googlegroups.com>
+ARG GO_VERSION
 
-RUN rm -rf /etc/service/sshd /etc/my_init.d/00_regen_ssh_host_keys.sh
-RUN apt-get update && apt-get install -y -q unzip openjdk-7-jre-headless git mercurial subversion
+RUN apt-get update
 
 RUN mkdir /etc/service/go-server
 ADD gocd-server/go-common-scripts.sh /etc/service/go-server/go-common-scripts.sh
 ADD gocd-server/go-server-start.sh /etc/service/go-server/run
 
-ADD https://download.go.cd/binaries/16.3.0-3183/deb/go-server-16.3.0-3183.deb /tmp/go-server.deb
+ADD https://download.go.cd/binaries/${GO_VERSION}/deb/go-server-${GO_VERSION}.deb /tmp/go-server.deb
 
 RUN ["groupadd", "-r", "go"]
 RUN ["useradd", "-r", "-c", "Go User", "-g", "go", "-d", "/var/go", "-m", "-s", "/bin/bash", "go"]

--- a/README.md
+++ b/README.md
@@ -1,15 +1,18 @@
 This is the repository which contains the Dockerfiles and supporting scripts for:
+[gocd-base](https://registry.hub.docker.com/u/gocd/gocd-base/),
+[gocd-dev](https://registry.hub.docker.com/u/gocd/gocd-dev/),
+[gocd-agent](https://registry.hub.docker.com/u/gocd/gocd-agent/),
+[gocd-server](https://registry.hub.docker.com/u/gocd/gocd-server/),
+[gocd-build-installer](https://registry.hub.docker.com/u/gocd/gocd-build-installer/)
 
-https://registry.hub.docker.com/u/gocd/gocd-dev/
+Follow those URLs for more details about the actual images. 
 
-https://registry.hub.docker.com/u/gocd/gocd-agent/
+For instructions to build the Docker images yourself, check
+the first line of each Dockerfile.  You can also use [rake](https://github.com/ruby/rake) to build these image for more information:
 
-https://registry.hub.docker.com/u/gocd/gocd-server/
-
-https://registry.hub.docker.com/u/gocd/gocd-build-installer/
-
-Follow those URLs for more details about the actual images. For instructions to build the Docker images yourself, check
-the first line of each Dockerfile.
+```
+$ rake --tasks
+```
 
 ## Contributing
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,57 @@
+require 'json'
+
+def verify_version(version, task)
+  unless version
+    puts "Please specify a version for building the docker image"
+    puts "e.g. \n GO_VERSION=16.x.x-xxxx rake #{task}"
+    puts "or"
+    puts "If you want to push the built image to a repository"
+    puts "e.g. \n GO_VERSION=16.x.x-xxxx REPOSITORY=repository_name rake #{task}"
+    exit(1)
+  end
+end
+
+def container_name(repository, type)
+  return repository ? "#{repository}/#{type}" : type 
+end
+
+def docker_build (repository, task, version)
+  verify_version(version, task)
+
+  type = "gocd-#{task}"
+  container = container_name(repository, type)
+
+  sh("docker build --build-arg GO_VERSION='#{version}' -f Dockerfile.#{type} -t #{container} .")
+
+  if repository
+    sh("docker push #{container}")
+    sh("docker tag #{container} #{container}:#{version}")
+    sh("docker push #{container}:#{version}")
+  end
+end
+
+desc "Build and push the base gocd image"
+task :base do |t, args|
+  container = container_name(ENV['REPOSITORY'], "gocd-base")
+  sh("docker build -f Dockerfile.gocd-base -t #{container} .")
+  
+  if ENV['REPOSITORY']
+    sh("docker push #{container}")
+  end
+end
+
+desc "Build and push a specific version of GoCD agent docker container"
+task :agent do |t, args|
+  docker_build(ENV['REPOSITORY'], t, ENV['GO_VERSION'])
+end
+
+desc "Build and push a specific version of GoCD server docker container"
+task :server do |t, args|
+  docker_build(ENV['REPOSITORY'], t, ENV['GO_VERSION'])
+end
+
+desc "Build and push a specific version of GoCD development container with server and agent"
+task :dev do |t, args|
+  docker_build(ENV['REPOSITORY'], t, ENV['GO_VERSION'])
+end
+


### PR DESCRIPTION
Script to automate the docker build process.

Usage:

For installing gocd-agent  

```
$ GO_VERSION=16.4.0-3223 rake agent
```

To push the image to any repo

```
$ GO_VERSION=16.4.0-3223 GO_REPOSITORY=gocd rake agent
```
