### PR TITLE
Alpine based GoCD server Docker image.

### DIFF
--- a/Dockerfile.alpine-gocd-server
+++ b/Dockerfile.alpine-gocd-server
@@ -1,11 +1,11 @@
-# Build using              : GO_VERSION=16.x.x-xxxx docker build -f Dockerfile.alpine-gocd-server -tag=alpine-gocd-server .
+# Build using: GO_VERSION=16.x.x-xxxx docker build -f Dockerfile.alpine-gocd-server --tag=alpine-gocd-server .
 
 FROM delitescere/jdk:latest
 #ENV GO_VERSION=16.5.0-3305
 ENV GO_VERSION=16.6.0-3590
 MAINTAINER GoCD <go-cd-dev@googlegroups.com>
 
-# GoCD scripts currently require bash.  Only git support is bundled.
+# GoCD scripts used here work with ash -- bash not needed.  Only git support is bundled.
 RUN apk --no-cache add git
 
 # Exposing volumes in a simple manner, and setup links behind-the-scenes to match GoCD's directory structure

--- a/Dockerfile.alpine-gocd-server
+++ b/Dockerfile.alpine-gocd-server
@@ -1,0 +1,40 @@
+# Build using              : GO_VERSION=16.x.x-xxxx docker build -f Dockerfile.alpine-gocd-server -tag=alpine-gocd-server .
+
+FROM delitescere/jdk:latest
+#ENV GO_VERSION=16.5.0-3305
+ENV GO_VERSION=16.6.0-3590
+MAINTAINER GoCD <go-cd-dev@googlegroups.com>
+
+# GoCD scripts currently require bash.  Only git support is bundled.
+RUN apk --no-cache add git
+
+# Exposing volumes in a simple manner, and setup links behind-the-scenes to match GoCD's directory structure
+# This requires some bootstrapping in alpine-start.sh
+RUN mkdir -p /config/default /config/db /config/addons /config/plugins /artifacts /logs/go-server /var/lib/go-server/plugins /tmp && \
+  ln -sf /config /var/lib/go-server/config && \
+  ln -sf /config/etc /etc/go && \
+  ln -sf /config/db /var/lib/go-server/db && \
+  ln -sf /artifacts /var/lib/go-server/artifacts && \
+  ln -sf /logs /var/log/go-server && \
+  ln -sf /config/addons /var/lib/go-server/addons && \
+  ln -sf /config/plugins /var/lib/go-server/plugins/external
+
+VOLUME ["/config", "/artifacts", "/logs"]
+
+EXPOSE 8153 8154
+
+# Dockerized startup script.  Should work on more than Alpine, but YMMV.
+COPY gocd-server/alpine-start.sh /start
+
+CMD ["/start"]
+
+# Download Go and install into a consistent directory. Disable daemonize.
+WORKDIR /
+RUN wget -qO- https://download.go.cd/binaries/$GO_VERSION/generic/go-server-$GO_VERSION.zip \
+  # Using 'jar' because 'unzip' doesn't support stdin, and bsdtar is not available on Alpine
+  |jar xvf /dev/stdin && \
+  # Note this rename won't work if /go-server already exists... (it'll move the dir inside /go-server)
+  mv ./go-server-* ./go-server && \
+  ls -alh /go-server && \
+  sed -e 's/DAEMON=Y/DAEMON=N/' /go-server/default.cruise-server > /config/default/go-server && \
+  rm -rf go-server-* /var/tmp/* /go-server/init.* /go-server/server.cmd /go-server/*.bat /go-server/*.sh /go-server/default.* /go-server/defaultFiles

--- a/Dockerfile.alpine-gocd-server
+++ b/Dockerfile.alpine-gocd-server
@@ -11,13 +11,13 @@ RUN apk --no-cache add git
 # Exposing volumes in a simple manner, and setup links behind-the-scenes to match GoCD's directory structure
 # This requires some bootstrapping in alpine-start.sh
 RUN mkdir -p /config/default /config/db /config/addons /config/plugins /artifacts /logs /var/lib/go-server/plugins /tmp && \
-  ln -sf /config /var/lib/go-server/config && \
-  ln -sf /config/etc /etc/go && \
-  ln -sf /config/db /var/lib/go-server/db && \
   ln -sf /artifacts /var/lib/go-server/artifacts && \
-  ln -sf /logs /var/log/go-server && \
+  ln -sf /config /var/lib/go-server/config && \
   ln -sf /config/addons /var/lib/go-server/addons && \
-  ln -sf /config/plugins /var/lib/go-server/plugins/external
+  ln -sf /config/db /var/lib/go-server/db && \
+  ln -sf /config/etc /etc/go && \
+  ln -sf /config/plugins /var/lib/go-server/plugins/external && \
+  ln -sf /logs /var/log/go-server
 
 VOLUME ["/config", "/artifacts", "/logs"]
 
@@ -32,10 +32,10 @@ CMD ["/start"]
 WORKDIR /
 RUN wget -qO- https://download.go.cd/binaries/$GO_VERSION/generic/go-server-$GO_VERSION.zip \
   # Using 'jar' because 'unzip' doesn't support stdin, and bsdtar is not available on Alpine
-  |jar xvf /dev/stdin && \
+  # Can't extract only specific files because we're working on stdin.
+  |jar xf /dev/stdin && \
   # Note this rename won't work if /go-server already exists... (it'll move the dir inside /go-server)
   mv ./go-server-* ./go-server && \
-  ls -alh /go-server && \
   sed -e 's/DAEMON=Y/DAEMON=N/' /go-server/default.cruise-server > /config/default/go-server && \
   # Trash any temp files
   rm -rf go-server-* /var/tmp/* /go-server/init.* /go-server/server.cmd /go-server/*.bat /go-server/*.sh /go-server/default.* /go-server/defaultFiles

--- a/Dockerfile.alpine-gocd-server
+++ b/Dockerfile.alpine-gocd-server
@@ -10,7 +10,7 @@ RUN apk --no-cache add git
 
 # Exposing volumes in a simple manner, and setup links behind-the-scenes to match GoCD's directory structure
 # This requires some bootstrapping in alpine-start.sh
-RUN mkdir -p /config/default /config/db /config/addons /config/plugins /artifacts /logs/go-server /var/lib/go-server/plugins /tmp && \
+RUN mkdir -p /config/default /config/db /config/addons /config/plugins /artifacts /logs /var/lib/go-server/plugins /tmp && \
   ln -sf /config /var/lib/go-server/config && \
   ln -sf /config/etc /etc/go && \
   ln -sf /config/db /var/lib/go-server/db && \
@@ -37,4 +37,5 @@ RUN wget -qO- https://download.go.cd/binaries/$GO_VERSION/generic/go-server-$GO_
   mv ./go-server-* ./go-server && \
   ls -alh /go-server && \
   sed -e 's/DAEMON=Y/DAEMON=N/' /go-server/default.cruise-server > /config/default/go-server && \
+  # Trash any temp files
   rm -rf go-server-* /var/tmp/* /go-server/init.* /go-server/server.cmd /go-server/*.bat /go-server/*.sh /go-server/default.* /go-server/defaultFiles

--- a/Dockerfile.alpine-gocd-server
+++ b/Dockerfile.alpine-gocd-server
@@ -1,8 +1,9 @@
-# Build using: GO_VERSION=16.x.x-xxxx docker build -f Dockerfile.alpine-gocd-server --tag=alpine-gocd-server .
+# Build using: docker build --build-arg GO_VERSION=16.x.x-xxxx -f Dockerfile.alpine-gocd-server --tag=alpine-gocd-server .
 
 FROM delitescere/jdk:latest
-#ENV GO_VERSION=16.5.0-3305
-ENV GO_VERSION=16.6.0-3590
+#16.5.0-3305
+#16.6.0-3590
+ARG GO_VERSION=16.6.0-3590
 MAINTAINER GoCD <go-cd-dev@googlegroups.com>
 
 # GoCD scripts used here work with ash -- bash not needed.  Only git support is bundled.
@@ -31,7 +32,8 @@ CMD ["/start"]
 
 # Download Go and install into a consistent directory. Disable daemonize.
 WORKDIR /
-RUN wget -qO- https://download.go.cd/binaries/$GO_VERSION/generic/go-server-$GO_VERSION.zip \
+LABEL cd.go.version=$GO_VERSION cd.go.server=""
+RUN echo "Installing GoCD ${GO_VERSION}" && wget -qO- https://download.go.cd/binaries/$GO_VERSION/generic/go-server-$GO_VERSION.zip \
   # Using 'jar' because 'unzip' doesn't support stdin, and bsdtar is not available on Alpine
   # Can't extract only specific files because we're working on stdin.
   |jar xf /dev/stdin && \

--- a/Dockerfile.alpine-gocd-server
+++ b/Dockerfile.alpine-gocd-server
@@ -12,10 +12,11 @@ RUN apk --no-cache add git
 # This requires some bootstrapping in alpine-start.sh
 RUN mkdir -p /config/default /config/db /config/addons /config/plugins /artifacts /logs /var/lib/go-server/plugins /tmp && \
   ln -sf /artifacts /var/lib/go-server/artifacts && \
+  # Link to /etc/go is likely unnecessary
+  ln -sf /config /etc/go && \
   ln -sf /config /var/lib/go-server/config && \
   ln -sf /config/addons /var/lib/go-server/addons && \
   ln -sf /config/db /var/lib/go-server/db && \
-  ln -sf /config/etc /etc/go && \
   ln -sf /config/plugins /var/lib/go-server/plugins/external && \
   ln -sf /logs /var/log/go-server
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,17 @@ https://registry.hub.docker.com/u/gocd/gocd-build-installer/
 Follow those URLs for more details about the actual images. For instructions to build the Docker images yourself, check
 the first line of each Dockerfile.
 
+## Version control system clients
+
+To keep image size minimal the GoCD server image only contains the Git client. To add other clients create your own image using this as a base.
+
+e.x. to add Subversion:
+```
+FROM gocd/gocd-server:<version>
+RUN apk --no-cache add subversion
+```
+
+
 ## Contributing
 
 We encourage you to contribute to Go. For information on contributing to this project, please see our [contributor's guide](http://www.go.cd/contribute).

--- a/gocd-server/alpine-start.sh
+++ b/gocd-server/alpine-start.sh
@@ -64,8 +64,6 @@ location of your Java installation."
 
 [ ! -z $SERVER_MEM ] || SERVER_MEM="512m"
 [ ! -z $SERVER_MAX_MEM ] || SERVER_MAX_MEM="1024m"
-[ ! -z $SERVER_MAX_PERM_GEN ] || SERVER_MAX_PERM_GEN="256m"
-[ ! -z $SERVER_MIN_PERM_GEN ] || SERVER_MIN_PERM_GEN="128m"
 [ ! -z $GO_SERVER_PORT ] || GO_SERVER_PORT="8153"
 [ ! -z $GO_SERVER_SSL_PORT ] || GO_SERVER_SSL_PORT="8154"
 [ ! -z "$SERVER_WORK_DIR" ] || SERVER_WORK_DIR="/var/lib/go-server"
@@ -118,8 +116,8 @@ if [ ! -d /config/db ]; then
 fi
 
 echo "Preparing database migrations."
-unzip -qq /go-server/go.jar defaultFiles/h2deltas.zip
-unzip -qq defaultFiles/h2deltas.zip -d /config/db
+unzip -qqo /go-server/go.jar defaultFiles/h2deltas.zip
+unzip -qqo defaultFiles/h2deltas.zip -d /config/db
 
 rm -rf defaultFiles
 
@@ -128,14 +126,20 @@ rm -rf defaultFiles
 [[ ! -d /config/default ]] && mkdir -p /config/default
 [[ ! -d /config/etc ]] && mkdir -p /config/etc
 
-SERVER_STARTUP_ARGS="-server -Djava.security.egd=file:/dev/./urandom -XX:HeapDumpPath=/logs -XX:ErrorFile=/logs/jvm-error.log"
-SERVER_STARTUP_ARGS="${SERVER_STARTUP_ARGS} -Xms$SERVER_MEM -Xmx$SERVER_MAX_MEM -XX:PermSize=$SERVER_MIN_PERM_GEN -XX:MaxPermSize=$SERVER_MAX_PERM_GEN"
-SERVER_STARTUP_ARGS="${SERVER_STARTUP_ARGS} ${JVM_DEBUG} ${GC_LOG} ${GO_SERVER_SYSTEM_PROPERTIES}"
-SERVER_STARTUP_ARGS="${SERVER_STARTUP_ARGS} -Duser.language=en -Djruby.rack.request.size.threshold.bytes=30000000"
-SERVER_STARTUP_ARGS="${SERVER_STARTUP_ARGS} -Duser.country=US -Dcruise.config.dir=$GO_CONFIG_DIR -Dcruise.config.file=$GO_CONFIG_DIR/gocd-server-config.xml"
-SERVER_STARTUP_ARGS="${SERVER_STARTUP_ARGS} -Dcruise.server.port=$GO_SERVER_PORT -Dcruise.server.ssl.port=$GO_SERVER_SSL_PORT"
+SERVER_STARTUP_ARGS="${SERVER_STARTUP_ARGS} "
+SERVER_STARTUP_ARGS="${SERVER_STARTUP_ARGS} "
+SERVER_STARTUP_ARGS="${SERVER_STARTUP_ARGS} "
 
-echo Starting GoCD server with command: $(autoDetectJavaExecutable) -jar /go-server/go.jar ${SERVER_STARTUP_ARGS}
+echo_or_exec_go() {
+  sh_command=${1-'exec'}
+  gocd_command="$(autoDetectJavaExecutable) -Dsun.jnu.encoding=UTF-8 -server -Djava.security.egd=file:/dev/./urandom -XX:HeapDumpPath=/logs -XX:ErrorFile=/logs/jvm-error.log -Xms$SERVER_MEM -Xmx$SERVER_MAX_MEM ${JVM_DEBUG} ${GC_LOG} ${GO_SERVER_SYSTEM_PROPERTIES} -Duser.language=en -Djruby.rack.request.size.threshold.bytes=30000000 -Duser.country=US -Dcruise.config.dir=$GO_CONFIG_DIR -Dcruise.config.file=$GO_CONFIG_DIR/gocd-server-config.xml -Dcruise.server.port=$GO_SERVER_PORT -Dcruise.server.ssl.port=$GO_SERVER_SSL_PORT -jar /go-server/go.jar"
+  export -p LANG="UTF-8"
+  eval "${sh_command} ${gocd_command}"
+}
+# exec java -jar /go-server/go.jar -server -Djava.security.egd=file:/dev/./urandom -XX:HeapDumpPath=/logs -XX:ErrorFile=/logs/jvm-error.log -Xms$SERVER_MEM -Xmx$SERVER_MAX_MEM -XX:PermSize=$SERVER_MIN_PERM_GEN -XX:MaxPermSize=$SERVER_MAX_PERM_GEN ${JVM_DEBUG} ${GC_LOG} ${GO_SERVER_SYSTEM_PROPERTIES} -Duser.language=en -Djruby.rack.request.size.threshold.bytes=30000000 -Duser.country=US -Dcruise.config.dir=/config -Dcruise.config.file=/config/gocd-server-config.xml
+# exec java -jar /go-server/go.jar -server -Dsun.jnu.encoding=UTF-8 -Djava.security.egd=file:/dev/./urandom -XX:HeapDumpPath=/logs -XX:ErrorFile=/logs/jvm-error.log -Duser.language=en -Djruby.rack.request.size.threshold.bytes=30000000 -Duser.country=US -Dcruise.config.dir=/config -Dcruise.config.file=/config/gocd-server-config.xml
+echo_or_exec_go "echo Starting GoCD server with command:"
 echo Starting GoCD server in directory: $SERVER_WORK_DIR
 cd "$SERVER_WORK_DIR"
-exec $(autoDetectJavaExecutable) -jar /go-server/go.jar ${SERVER_STARTUP_ARGS}
+# exec $(autoDetectJavaExecutable) -jar /go-server/go.jar ${SERVER_STARTUP_ARGS}
+echo_or_exec_go

--- a/gocd-server/alpine-start.sh
+++ b/gocd-server/alpine-start.sh
@@ -123,7 +123,7 @@ fi
 [[ ! -d /config/default ]] && mkdir -p /config/default
 [[ ! -d /config/etc ]] && mkdir -p /config/etc
 
-SERVER_STARTUP_ARGS="-server -Djava.security.egd=file:/dev/./urandom"
+SERVER_STARTUP_ARGS="-server -Djava.security.egd=file:/dev/./urandom -XX:HeapDumpPath=/logs -XX:ErrorFile=/logs/jvm-error.log"
 SERVER_STARTUP_ARGS="${SERVER_STARTUP_ARGS} -Xms$SERVER_MEM -Xmx$SERVER_MAX_MEM -XX:PermSize=$SERVER_MIN_PERM_GEN -XX:MaxPermSize=$SERVER_MAX_PERM_GEN"
 SERVER_STARTUP_ARGS="${SERVER_STARTUP_ARGS} ${JVM_DEBUG} ${GC_LOG} ${GO_SERVER_SYSTEM_PROPERTIES}"
 SERVER_STARTUP_ARGS="${SERVER_STARTUP_ARGS} -Duser.language=en -Djruby.rack.request.size.threshold.bytes=30000000"
@@ -133,5 +133,4 @@ SERVER_STARTUP_ARGS="${SERVER_STARTUP_ARGS} -Dcruise.server.port=$GO_SERVER_PORT
 echo Starting Go Server with command: $(autoDetectJavaExecutable) -jar /go-server/go.jar ${SERVER_STARTUP_ARGS}
 echo Starting Go Server in directory: $SERVER_WORK_DIR
 cd "$SERVER_WORK_DIR"
-
 exec $(autoDetectJavaExecutable) -jar /go-server/go.jar ${SERVER_STARTUP_ARGS}

--- a/gocd-server/alpine-start.sh
+++ b/gocd-server/alpine-start.sh
@@ -125,10 +125,10 @@ fi
 
 SERVER_STARTUP_ARGS="-server -Djava.security.egd=file:/dev/./urandom"
 SERVER_STARTUP_ARGS="${SERVER_STARTUP_ARGS} -Xms$SERVER_MEM -Xmx$SERVER_MAX_MEM -XX:PermSize=$SERVER_MIN_PERM_GEN -XX:MaxPermSize=$SERVER_MAX_PERM_GEN"
-SERVER_STARTUP_ARGS="${SERVER_STARTUP_ARGS}  ${JVM_DEBUG} ${GC_LOG} ${GO_SERVER_SYSTEM_PROPERTIES}"
-SERVER_STARTUP_ARGS="${SERVER_STARTUP_ARGS}  -Duser.language=en -Djruby.rack.request.size.threshold.bytes=30000000"
-SERVER_STARTUP_ARGS="${SERVER_STARTUP_ARGS}  -Duser.country=US -Dcruise.config.dir=$GO_CONFIG_DIR -Dcruise.config.file=$GO_CONFIG_DIR/gocd-server-config.xml"
-sSERVER_STARTUP_ARGS="${SERVER_STARTUP_ARGS}  -Dcruise.server.port=$GO_SERVER_PORT -Dcruise.server.ssl.port=$GO_SERVER_SSL_PORT"
+SERVER_STARTUP_ARGS="${SERVER_STARTUP_ARGS} ${JVM_DEBUG} ${GC_LOG} ${GO_SERVER_SYSTEM_PROPERTIES}"
+SERVER_STARTUP_ARGS="${SERVER_STARTUP_ARGS} -Duser.language=en -Djruby.rack.request.size.threshold.bytes=30000000"
+SERVER_STARTUP_ARGS="${SERVER_STARTUP_ARGS} -Duser.country=US -Dcruise.config.dir=$GO_CONFIG_DIR -Dcruise.config.file=$GO_CONFIG_DIR/gocd-server-config.xml"
+SERVER_STARTUP_ARGS="${SERVER_STARTUP_ARGS} -Dcruise.server.port=$GO_SERVER_PORT -Dcruise.server.ssl.port=$GO_SERVER_SSL_PORT"
 
 echo Starting Go Server with command: $(autoDetectJavaExecutable) -jar /go-server/go.jar ${SERVER_STARTUP_ARGS}
 echo Starting Go Server in directory: $SERVER_WORK_DIR

--- a/gocd-server/alpine-start.sh
+++ b/gocd-server/alpine-start.sh
@@ -1,0 +1,137 @@
+#!/bin/sh
+##########################################################################
+# Copyright 2016 ThoughtWorks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+MANUAL_SETTING=${MANUAL_SETTING:-"N"}
+
+if [ "$MANUAL_SETTING" == "N" ]; then
+    if [ -f /config/default/go-server ]; then
+        echo "[$(date)] using default settings from /config/default/go-server"
+        . /config/default/go-server
+    fi
+fi
+
+yell() {
+  echo "$*" >&2;
+}
+
+die() {
+    yell "$1"
+    exit ${2:-1}
+}
+
+autoDetectJavaExecutable() {
+  local java_cmd
+  # Prefer using GO_JAVA_HOME, over JAVA_HOME
+  GO_JAVA_HOME=${GO_JAVA_HOME:-"$JAVA_HOME"}
+
+  if [ -n "$GO_JAVA_HOME" ] ; then
+      if [ -x "$GO_JAVA_HOME/jre/sh/java" ] ; then
+          # IBM's JDK on AIX uses strange locations for the executables
+          java_cmd="$GO_JAVA_HOME/jre/sh/java"
+      else
+          java_cmd="$GO_JAVA_HOME/bin/java"
+      fi
+      if [ ! -x "$java_cmd" ] ; then
+          die "ERROR: GO_JAVA_HOME is set to an invalid directory: $GO_JAVA_HOME
+
+Please set the GO_JAVA_HOME variable in your environment to match the
+location of your Java installation."
+      fi
+  else
+      java_cmd="java"
+      which java >/dev/null 2>&1 || die "ERROR: GO_JAVA_HOME is not set and no 'java' command could be found in your PATH.
+
+Please set the GO_JAVA_HOME variable in your environment to match the
+location of your Java installation."
+  fi
+
+  echo "$java_cmd"
+}
+
+[ ! -z $SERVER_MEM ] || SERVER_MEM="512m"
+[ ! -z $SERVER_MAX_MEM ] || SERVER_MAX_MEM="1024m"
+[ ! -z $SERVER_MAX_PERM_GEN ] || SERVER_MAX_PERM_GEN="256m"
+[ ! -z $SERVER_MIN_PERM_GEN ] || SERVER_MIN_PERM_GEN="128m"
+[ ! -z $GO_SERVER_PORT ] || GO_SERVER_PORT="8153"
+[ ! -z $GO_SERVER_SSL_PORT ] || GO_SERVER_SSL_PORT="8154"
+[ ! -z "$SERVER_WORK_DIR" ] || SERVER_WORK_DIR="/var/lib/go-server"
+[ ! -z "$YOURKIT_DISABLE_TRACING" ] || YOURKIT_DISABLE_TRACING=""
+
+if [ -d /logs ]; then
+    STDOUT_LOG_FILE=/logs/go-server.out.log
+else
+    STDOUT_LOG_FILE=go-server.out.log
+fi
+
+if [ -d /var/run/go-server ]; then
+    PID_FILE=/var/run/go-server/go-server.pid
+else
+    PID_FILE=go-server.pid
+fi
+
+GO_CONFIG_DIR=/var/lib/go-server/config
+
+if [ "$JVM_DEBUG" != "" ]; then
+    JVM_DEBUG="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005"
+else
+    JVM_DEBUG=''
+fi
+
+if [ "$GC_LOG" != "" ]; then
+    GC_LOG="-verbose:gc -Xloggc:go-server-gc.log -XX:+PrintGCTimeStamps -XX:+PrintTenuringDistribution -XX:+PrintGCDetails -XX:+PrintGC"
+else
+    GC_LOG=''
+fi
+
+if [ ! -z $SERVER_LISTEN_HOST ]; then
+    GO_SERVER_SYSTEM_PROPERTIES+="-Dcruise.listen.host=$SERVER_LISTEN_HOST"
+fi
+
+
+# Bootstrapping
+if [ ! -f /config/gocd-server-config.xml ]; then
+  echo "Bootstrapping initial configuration."
+  unzip -qq /go-server/go.jar defaultFiles/config/cruise-config.xml
+  cp defaultFiles/config/cruise-config.xml /config/gocd-server-config.xml
+fi
+AGENT_KEY="${AGENT_KEY:-123456789abcdef}"
+[[ -n "$AGENT_KEY" ]] && sed -i -e 's/agentAutoRegisterKey="[^"]*" *//' -e 's#\(<server\)\(.*artifactsdir.*\)#\1 agentAutoRegisterKey="'$AGENT_KEY'"\2#' /config/gocd-server-config.xml
+if [ ! -d /config/db ]; then
+  echo "Bootstrapping database."
+  mkdir /config/db
+  unzip -qq /go-server/go.jar defaultFiles/h2db.zip defaultFiles/h2deltas.zip
+  unzip -qq defaultFiles/h2db.zip -d /config/db
+  unzip -qq defaultFiles/h2deltas.zip -d /config/db
+fi
+
+[[ ! -d /config/addons ]] && mkdir /config/addons
+[[ ! -d /config/plugins ]] && mkdir /config/plugins
+[[ ! -d /config/default ]] && mkdir -p /config/default
+[[ ! -d /config/etc ]] && mkdir -p /config/etc
+
+SERVER_STARTUP_ARGS="-server -Djava.security.egd=file:/dev/./urandom"
+SERVER_STARTUP_ARGS="${SERVER_STARTUP_ARGS} -Xms$SERVER_MEM -Xmx$SERVER_MAX_MEM -XX:PermSize=$SERVER_MIN_PERM_GEN -XX:MaxPermSize=$SERVER_MAX_PERM_GEN"
+SERVER_STARTUP_ARGS="${SERVER_STARTUP_ARGS}  ${JVM_DEBUG} ${GC_LOG} ${GO_SERVER_SYSTEM_PROPERTIES}"
+SERVER_STARTUP_ARGS="${SERVER_STARTUP_ARGS}  -Duser.language=en -Djruby.rack.request.size.threshold.bytes=30000000"
+SERVER_STARTUP_ARGS="${SERVER_STARTUP_ARGS}  -Duser.country=US -Dcruise.config.dir=$GO_CONFIG_DIR -Dcruise.config.file=$GO_CONFIG_DIR/gocd-server-config.xml"
+sSERVER_STARTUP_ARGS="${SERVER_STARTUP_ARGS}  -Dcruise.server.port=$GO_SERVER_PORT -Dcruise.server.ssl.port=$GO_SERVER_SSL_PORT"
+
+echo Starting Go Server with command: $(autoDetectJavaExecutable) -jar /go-server/go.jar ${SERVER_STARTUP_ARGS}
+echo Starting Go Server in directory: $SERVER_WORK_DIR
+cd "$SERVER_WORK_DIR"
+
+exec $(autoDetectJavaExecutable) -jar /go-server/go.jar ${SERVER_STARTUP_ARGS}

--- a/gocd-server/alpine-start.sh
+++ b/gocd-server/alpine-start.sh
@@ -113,10 +113,15 @@ AGENT_KEY="${AGENT_KEY:-123456789abcdef}"
 if [ ! -d /config/db ]; then
   echo "Bootstrapping database."
   mkdir /config/db
-  unzip -qq /go-server/go.jar defaultFiles/h2db.zip defaultFiles/h2deltas.zip
+  unzip -qq /go-server/go.jar defaultFiles/h2db.zip
   unzip -qq defaultFiles/h2db.zip -d /config/db
-  unzip -qq defaultFiles/h2deltas.zip -d /config/db
 fi
+
+echo "Preparing database migrations."
+unzip -qq /go-server/go.jar defaultFiles/h2deltas.zip
+unzip -qq defaultFiles/h2deltas.zip -d /config/db
+
+rm -rf defaultFiles
 
 [[ ! -d /config/addons ]] && mkdir /config/addons
 [[ ! -d /config/plugins ]] && mkdir /config/plugins
@@ -130,7 +135,7 @@ SERVER_STARTUP_ARGS="${SERVER_STARTUP_ARGS} -Duser.language=en -Djruby.rack.requ
 SERVER_STARTUP_ARGS="${SERVER_STARTUP_ARGS} -Duser.country=US -Dcruise.config.dir=$GO_CONFIG_DIR -Dcruise.config.file=$GO_CONFIG_DIR/gocd-server-config.xml"
 SERVER_STARTUP_ARGS="${SERVER_STARTUP_ARGS} -Dcruise.server.port=$GO_SERVER_PORT -Dcruise.server.ssl.port=$GO_SERVER_SSL_PORT"
 
-echo Starting Go Server with command: $(autoDetectJavaExecutable) -jar /go-server/go.jar ${SERVER_STARTUP_ARGS}
-echo Starting Go Server in directory: $SERVER_WORK_DIR
+echo Starting GoCD server with command: $(autoDetectJavaExecutable) -jar /go-server/go.jar ${SERVER_STARTUP_ARGS}
+echo Starting GoCD server in directory: $SERVER_WORK_DIR
 cd "$SERVER_WORK_DIR"
 exec $(autoDetectJavaExecutable) -jar /go-server/go.jar ${SERVER_STARTUP_ARGS}


### PR DESCRIPTION
~ 212MB image

Notable changes:
- New Dockerfile (not erb) for Alpine
- Installs via the zip package, and ignores most of the contents
- Simplifies the volumes exposed (/config, /logs, /artifacts) and maps GoCD's directory structure into it
  -- This required some bootstrapping for the h2db bundles zips.
