### PR TITLE
ONBUILD so that volumes still get exposed when this is used as a base…

### DIFF
--- a/Dockerfile.alpine-gocd-server
+++ b/Dockerfile.alpine-gocd-server
@@ -22,6 +22,7 @@ RUN mkdir -p /config/default /config/db /config/addons /config/plugins /artifact
   ln -sf /logs /var/log/go-server
 
 VOLUME ["/config", "/artifacts", "/logs"]
+ONBUILD VOLUME ["/config", "/artifacts", "/logs"]
 
 EXPOSE 8153 8154
 


### PR DESCRIPTION
Minor change.  Introduces an ONBUILD so that people can use the Alpine server image as a base.  (e.g. - FROM gocd/alpine-gocd-server)

Essentially:

```
FROM gocd/alpine-gocd-server:latest
RUN apk --no-cache add any-other-packages-they-want
```

and they're done.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gocd/gocd-docker/44)
<!-- Reviewable:end -->
