### PR TITLE
Kubernetes example

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,0 +1,18 @@
+This folder contains example yaml files for running GoCD in Kubernetes.  Note that at this time it uses a _static_ agent pool.
+
+- agents.yaml - replication controller for GoCD agents
+- server.yaml - replication controller for a GoCD server
+- local-service.yaml - service endpoint (NodePort type) for a local Kubernetes install
+- gce-service.yaml - service endpoint (LoadBalancer type) for GCE Kubernetes.
+
+# Running
+Assuming you have an existing Kubernetes cluster running, with kubectl configured:
+```
+kubectl create --filename server.yaml
+kubectl create --filename gce-service.yaml (or local-service.yaml)
+kubectl create --filename agents.yaml
+
+```
+
+# Note
+GoCD's server container is not yet published using the image exposing /config, /artifacts, /logs volumes. In the interim server.yaml references my (@tpbrown) GoCD server image.

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -16,3 +16,5 @@ kubectl create --filename agents.yaml
 
 # Note
 GoCD's server container is not yet published using the image exposing /config, /artifacts, /logs volumes. In the interim server.yaml references my (@tpbrown) GoCD server image.
+
+**This example does not use persistent volumes. If the server pod dies you _will_ lose data.**

--- a/kubernetes/agents.yaml
+++ b/kubernetes/agents.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: gocd-agent-linux
+  labels:
+    app: gocd-agent-linux
+spec:
+  replicas: 2
+  selector:
+    app: gocd-agent-linux
+  template:
+    metadata:
+      labels:
+        app: gocd-agent-linux
+    spec:
+      containers:
+      - name: gocd-agent-linux
+        image: gocd/gocd-agent:latest
+        env:
+          - name: GO_SERVER
+            value: $GOCD_SERVICE_HOST
+          - name: GO_SERVER_PORT
+            value: $GOCD_SERVICE_PORT_WEBUI
+        resources:
+          limits:
+            memory: "1000Mi"
+            cpu: "1"

--- a/kubernetes/gce-service.yaml
+++ b/kubernetes/gce-service.yaml
@@ -1,0 +1,18 @@
+---
+  apiVersion: "v1"
+  kind: "Service"
+  metadata:
+    name: "gocd"
+  spec:
+    type: "LoadBalancer"
+    selector:
+      app: "gocd"
+    ports:
+      -
+        name: "webui"
+        port: 8153
+        protocol: "TCP"
+      -
+        name: "agent"
+        port: 8154
+        protocol: "TCP"

--- a/kubernetes/local-service.yaml
+++ b/kubernetes/local-service.yaml
@@ -1,0 +1,18 @@
+---
+  apiVersion: "v1"
+  kind: "Service"
+  metadata:
+    name: "gocd"
+  spec:
+    type: "NodePort"
+    selector:
+      app: "gocd"
+    ports:
+      -
+        name: "webui"
+        port: 8153
+        protocol: "TCP"
+      -
+        name: "agent"
+        port: 8154
+        protocol: "TCP"

--- a/kubernetes/server.yaml
+++ b/kubernetes/server.yaml
@@ -1,0 +1,31 @@
+---
+  apiVersion: "v1"
+  kind: "ReplicationController"
+  metadata:
+    name: "gocd"
+  spec:
+    replicas: 1
+    template:
+      metadata:
+        labels:
+          app: "gocd"
+      spec:
+        containers:
+          - name: "gocd"
+            image: "tpbrown/gocd-docker:latest"
+            ports:
+              - containerPort: 8153
+              - containerPort: 8154
+        #     volumeMounts:
+        #       - name: "gocd-data"
+        #         mountPath: "/var/gocd_home"
+        #     livenessProbe:
+        #       httpGet:
+        #         path: /
+        #         port: 8080
+        #       initialDelaySeconds: 60
+        #       timeoutSeconds: 5
+        # volumes:
+        #   - name: "gocd-data"
+        #     hostPath:
+        #       path: "/var/gocd"


### PR DESCRIPTION
Example of how to run GoCD in Kubernetes with a static agent pool using either GCE or a local K8 cluster.

It does **not** illustrate persistent volumes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gocd/gocd-docker/45)
<!-- Reviewable:end -->
