### PR TITLE
SSH keys and splitting to 2 images

### DIFF
--- a/Dockerfile.gocd-server
+++ b/Dockerfile.gocd-server
@@ -1,0 +1,10 @@
+# This Dockerfile produces a ready-to-run GoCD server that exposes volumes for /config, /logs, and /artifacts.
+# Build using: docker build -f Dockerfile.gocd-server --tag=gocd-server .
+
+# This always pulls the latest GoCD version.
+FROM alpine-server-baseimage:latest
+MAINTAINER GoCD <go-cd-dev@googlegroups.com>
+VOLUME ["/config", "/artifacts", "/logs"]
+
+# Prevent using this image as a base.
+ONBUILD RUN >&2 echo "This image should not be used as a base because it exposes volumes.  Please use gocd/alpine-server-baseimage instead." && exit 1

--- a/Dockerfile.server-baseimage
+++ b/Dockerfile.server-baseimage
@@ -1,4 +1,4 @@
-# Build using: docker build --build-arg GO_VERSION=16.x.x-xxxx -f Dockerfile.alpine-gocd-server --tag=alpine-gocd-server .
+# Build using: docker build --build-arg GO_VERSION=16.x.x-xxxx -f Dockerfile.server-baseimage --tag=alpine-server-baseimage .
 
 FROM delitescere/jdk:latest
 #16.5.0-3305
@@ -7,11 +7,20 @@ ARG GO_VERSION=16.6.0-3590
 MAINTAINER GoCD <go-cd-dev@googlegroups.com>
 
 # GoCD scripts used here work with ash -- bash not needed.  Only git support is bundled.
-RUN apk --no-cache add git
+RUN apk --no-cache add git openssh-client
 
 # Exposing volumes in a simple manner, and setup links behind-the-scenes to match GoCD's directory structure
 # This requires some bootstrapping in alpine-start.sh
-RUN mkdir -p /config/default /config/db /config/addons /config/plugins /artifacts /logs /var/lib/go-server/plugins /tmp && \
+RUN mkdir -p \
+  /artifacts \
+  /config/db \
+  /config/default \
+  /config/addons \
+  /config/plugins \
+  /config/ssh \
+  /logs \
+  /var/lib/go-server/plugins \
+  /tmp && \
   ln -sf /artifacts /var/lib/go-server/artifacts && \
   # Link to /etc/go is likely unnecessary
   ln -sf /config /etc/go && \
@@ -19,9 +28,11 @@ RUN mkdir -p /config/default /config/db /config/addons /config/plugins /artifact
   ln -sf /config/addons /var/lib/go-server/addons && \
   ln -sf /config/db /var/lib/go-server/db && \
   ln -sf /config/plugins /var/lib/go-server/plugins/external && \
-  ln -sf /logs /var/log/go-server
+  ln -sf /logs /var/log/go-server && \
+  ln -sf /config/ssh /root/.ssh
 
-VOLUME ["/config", "/artifacts", "/logs"]
+# Don't expose volumes in a base image -- people can't change the contents in downstream images.
+# VOLUME ["/config", "/artifacts", "/logs"]
 
 EXPOSE 8153 8154
 


### PR DESCRIPTION
Hello,

This PR addresses the volume issue raised in #21 and provides initial support for (basic) SSH key handling.

The Alpine-based GoCD server has been split into two images:
- 'server-baseimage' that contains GoCD, OpenSSH client, and Git. _This image exposes no volumes_ so that it's safe to use as a base image.
- 'gocd-server' that provides a ready-to-run GoCD server instance, using the above.  This image _does_ expose /artifacts, /config, and /logs volumes. 
  -- This image includes a safety-check to ensure that it's not used as a base image.

Basic support for SSH keys is handled by linking /root/.ssh to /config/ssh.  GoCD does no verification of the permissions of keys.

I have a bit of free time and will take a stab at providing an example setup using Vault for key management.   Ideally we'd have a single approach that serves both GoCD server and GoCD agents as both need the keys.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gocd/gocd-docker/46)
<!-- Reviewable:end -->
