### PR TITLE
Configure GO_SERVER_URL when starting go agent

### DIFF
--- a/gocd-agent/go-agent-start.sh
+++ b/gocd-agent/go-agent-start.sh
@@ -7,6 +7,7 @@ COLOR_END="[00m"
 
 echo -e "${COLOR_START}Starting Go Agent to connect to server $GO_SERVER ...${COLOR_END}"
 sed -i -e 's/GO_SERVER=.*/GO_SERVER='$GO_SERVER'/' /etc/default/go-agent
+sed -i -e 's/GO_SERVER_URL=.*/GO_SERVER_URL=https:\/\/'$GO_SERVER':8154\/go\//' /etc/default/go-agent
 
 mkdir -p /var/lib/go-agent/config
 /bin/rm -f /var/lib/go-agent/config/autoregister.properties


### PR DESCRIPTION
Newer versions of GoCD (I tried 16.7.0-3819) seem to only have `GO_SERVER_URL` in `/etc/default/go-agent` so when running the container, `go-agent-start.sh` can't find a `GO_SERVER` configuration to replace, leaving the default configuration in `GO_SERVER_URL` untouched and preventing autoconfiguration with the go-server: 

```
$ docker run -ti --link some-go-server-container:go-server gocd/gocd-agent
*** Running /etc/rc.local...
*** Booting runit daemon...
*** Runit started as PID 8
Starting Go Agent to connect to server go-server ...
[Sun Jul 31 11:28:20 UTC 2016] using default settings from /etc/default/go-agent
WARN: The environment variable GO_SERVER and GO_SERVER_PORT has been deprecated in favor of GO_SERVER_URL. Please set GO_SERVER_URL instead to a https url (https://example.com:8154/go)
logFile Environment Variable= null
Logging to go-agent-bootstrapper.log
0 [TouchLoopThread-2] INFO com.thoughtworks.go.agent.launcher.Lockfile  - Using lock file: /var/lib/go-agent/.agent-bootstrapper.running
331 [main] ERROR com.thoughtworks.go.agent.launcher.ServerCall  - Couldn't access Go Server with base url: https://127.0.0.1:8154/go/admin/agent-launcher.jar: org.apache.http.conn.HttpHostConnectException: Connect to 127.0.0.1:8154 [/127.0.0.1] failed: Connection refused
java.lang.Exception: Couldn't access Go Server with base url: https://127.0.0.1:8154/go/admin/agent-launcher.jar: org.apache.http.conn.HttpHostConnectException: Connect to 127.0.0.1:8154 [/127.0.0.1] failed: Connection refused
```

This PR adds support for `GO_SERVER_URL` while still supporting `GO_SERVER`
