### PR TITLE
Make sure go-agent config directory is writeable

### DIFF
--- a/gocd-agent/go-agent-start.sh
+++ b/gocd-agent/go-agent-start.sh
@@ -9,6 +9,8 @@ echo -e "${COLOR_START}Starting Go Agent to connect to server $GO_SERVER ...${CO
 sed -i -e 's/GO_SERVER=.*/GO_SERVER='$GO_SERVER'/' /etc/default/go-agent
 
 mkdir -p /var/lib/go-agent/config
+chown go /var/lib/go-agent/config
+
 /bin/rm -f /var/lib/go-agent/config/autoregister.properties
 
 AGENT_KEY="${AGENT_KEY:-123456789abcdef}"


### PR DESCRIPTION
I'm running into issues where the go-agent can't write to the config directory: 

```
Caused by: java.lang.RuntimeException: Couldn't save GUID to filesystem
        at com.thoughtworks.go.util.ExceptionUtils.bomb(ExceptionUtils.java:40)
        at com.thoughtworks.go.config.GuidService.storeGuid(GuidService.java:34)
        at com.thoughtworks.go.config.DefaultAgentRegistry.uuid(DefaultAgentRegistry.java:30)
        at com.thoughtworks.go.agent.AgentController.agentIdentifier(AgentController.java:166)
        at com.thoughtworks.go.agent.AgentController.init(AgentController.java:127)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:606)
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeCustomInitMethod(AbstractAutowireCapableBeanFactory.java:1581)
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeInitMethods(AbstractAutowireCapableBeanFactory.java:1522)
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1452)
        ... 18 more
Caused by: java.io.FileNotFoundException: config/guid.txt (Permission denied)
        at java.io.FileOutputStream.open(Native Method)
        at java.io.FileOutputStream.<init>(FileOutputStream.java:221)
        at org.apache.commons.io.FileUtils.openOutputStream(FileUtils.java:360)
        at org.apache.commons.io.FileUtils.writeStringToFile(FileUtils.java:1981)
        at org.apache.commons.io.FileUtils.writeStringToFile(FileUtils.java:2017)
```

This PR seems to fix this problem. 
