### PR TITLE
Docker file for creating centos agents with tinit.

### DIFF
--- a/Dockerfile.centos
+++ b/Dockerfile.centos
@@ -12,3 +12,8 @@ rm -f /lib/systemd/system/basic.target.wants/*;\
 rm -f /lib/systemd/system/anaconda.target.wants/*; \
 yum install -y java-1.8.0-openjdk-headless git;
 VOLUME [ "/sys/fs/cgroup" ]
+
+ENV TINI_VERSION v0.9.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+ENTRYPOINT ["/tini", "--"]

--- a/Dockerfile.centos
+++ b/Dockerfile.centos
@@ -1,0 +1,14 @@
+# docker build --rm -f Dockerfile.centos -t local/centos .
+FROM centos:7
+MAINTAINER "GoCD" <gocd-dev@googlegroups.com>
+ENV container docker
+RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+rm -f /lib/systemd/system/multi-user.target.wants/*;\
+rm -f /etc/systemd/system/*.wants/*;\
+rm -f /lib/systemd/system/local-fs.target.wants/*; \
+rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+rm -f /lib/systemd/system/basic.target.wants/*;\
+rm -f /lib/systemd/system/anaconda.target.wants/*; \
+yum install -y java-1.8.0-openjdk-headless git;
+VOLUME [ "/sys/fs/cgroup" ]

--- a/Dockerfile.centos.gocd-agent
+++ b/Dockerfile.centos.gocd-agent
@@ -1,12 +1,7 @@
 # docker build --rm -f Dockerfile.centos -t local/centos .
-# docker build --build-arg GO_VERSION=16.x.x-xxxx -f Dockerfile.centos.gocd-agent --rm -t centos/agent . 
+# docker build --build-arg GO_VERSION=16.x.x-xxxx -f Dockerfile.centos.gocd-agent --rm -t gocd-agent . 
 FROM local/centos
 ARG GO_VERSION="16.8.0-3889"
-
-ENV TINI_VERSION v0.9.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
-RUN chmod +x /tini
-ENTRYPOINT ["/tini", "--"]
 
 ADD https://download.go.cd/experimental/binaries/$GO_VERSION/rpm/go-agent-$GO_VERSION.noarch.rpm /tmp/go-agent.rpm
 

--- a/Dockerfile.centos.gocd-agent
+++ b/Dockerfile.centos.gocd-agent
@@ -1,0 +1,17 @@
+# docker build --rm -f Dockerfile.centos -t local/centos .
+# docker build --build-arg GO_VERSION=16.x.x-xxxx -f Dockerfile.centos.gocd-agent --rm -t centos/agent . 
+FROM local/centos
+ARG GO_VERSION="16.8.0-3889"
+
+ENV TINI_VERSION v0.9.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+ENTRYPOINT ["/tini", "--"]
+
+ADD https://download.go.cd/experimental/binaries/$GO_VERSION/rpm/go-agent-$GO_VERSION.noarch.rpm /tmp/go-agent.rpm
+
+WORKDIR /tmp
+RUN yum install -y /tmp/go-agent.rpm; yum clean all; rm -f /etc/default/go-server
+
+# Run your program under Tini
+CMD PRODUCTION_MODE=N /usr/share/go-agent/agent.sh


### PR DESCRIPTION
This starts the agent in no production mode to avoid setting default environment variables.
There are no script modifications while building the docker image. The environment variables
are to be set manually.

The idea is to have the same set of instructions on starting a normal agent or the docker agent and allow flexibility.

Any custom changes are to be done by modifying the docker file or using it as a base.
