### PR TITLE
Naming auto-registered go-agents

### DIFF
--- a/phusion/agent/go-agent-start.sh
+++ b/phusion/agent/go-agent-start.sh
@@ -18,5 +18,6 @@ AGENT_KEY="${AGENT_KEY:-123456789abcdef}"
 echo "agent.auto.register.key=$AGENT_KEY" >/var/lib/go-agent/config/autoregister.properties
 if [ -n "$AGENT_RESOURCES" ]; then echo "agent.auto.register.resources=$AGENT_RESOURCES" >>/var/lib/go-agent/config/autoregister.properties; fi
 if [ -n "$AGENT_ENVIRONMENTS" ]; then echo "agent.auto.register.environments=$AGENT_ENVIRONMENTS" >>/var/lib/go-agent/config/autoregister.properties; fi
+if [ -n "$AGENT_HOSTNAME" ]; then echo "agent.auto.register.hostname=$AGENT_HOSTNAME" >>/var/lib/go-agent/config/autoregister.properties; fi
 
 /sbin/setuser go /etc/init.d/go-agent start


### PR DESCRIPTION
Setting agent.auto.register.hostname as/when environment variable AGENT_HOSTNAME is set, allowing auto-registered agents to be named.
