### PR TITLE
Fix defaults to new name

### DIFF
--- a/alpine/server/Dockerfile
+++ b/alpine/server/Dockerfile
@@ -40,6 +40,6 @@ RUN echo "Installing GoCD ${GO_VERSION}" && wget -qO- $DOWNLOAD_URL/$GO_VERSION/
   |jar xf /dev/stdin && \
   # Note this rename won't work if /go-server already exists... (it'll move the dir inside /go-server)
   mv ./go-server-* ./go-server && \
-  sed -e 's/DAEMON=Y/DAEMON=N/' /go-server/default.cruise-server > /config/default/go-server && \
+  sed -e 's/DAEMON=Y/DAEMON=N/' /go-server/go-server.default > /config/default/go-server && \
   # Trash any temp files
   rm -rf go-server-* /var/tmp/* /go-server/init.* /go-server/server.cmd /go-server/*.bat /go-server/*.sh /go-server/default.* /go-server/defaultFiles


### PR DESCRIPTION
Change the sed command to bring over the defaults from the new go-server.default.
