### PR TITLE
Use docker-machine instead of boot2docker

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,9 @@
 # Contributing
 
-We encourage you to contribute to Go. For information on contributing to this project, please see our <a href="http://www.go.cd/contribute/">contributor's guide</a>.
-A lot of useful information like links to user documentation, design documentation, mailing lists etc can be found in the <a href="http://www.go.cd/community/resources.html">resources</a> section.
+We encourage you to contribute to Go. For information on contributing to this project, please see our <a href="http://www.gocd.io/contribute/">contributor's guide</a>.
+A lot of useful information like links to user documentation, design documentation, mailing lists etc can be found in the <a href="http://www.gocd.io/community/resources.html">resources</a> section.
 
 ## Contributing Code?
 
-Signing the [Contributor License Agreement (CLA)](http://www.go.cd/contribute/cla.html) is required before any of your code or pull-requests are accepted.
+Signing the [Contributor License Agreement (CLA)](http://www.gocd.io/contribute/cla.html) is required before any of your code or pull-requests are accepted.
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ the first line of each Dockerfile.
 
 ## Contributing
 
-We encourage you to contribute to Go. For information on contributing to this project, please see our [contributor's guide](http://www.go.cd/contribute).
-A lot of useful information like links to user documentation, design documentation, mailing lists etc. can be found in the [resources](http://www.go.cd/community/resources.html) section.
+We encourage you to contribute to Go. For information on contributing to this project, please see our [contributor's guide](http://www.gocd.io/contribute).
+A lot of useful information like links to user documentation, design documentation, mailing lists etc. can be found in the [resources](http://www.gocd.io/community/resources.html) section.
 
 ## License
 

--- a/phusion/server/go-server-start.sh
+++ b/phusion/server/go-server-start.sh
@@ -28,7 +28,7 @@ If you're using docker on a Linux box, you can do this:
 ${COLOR_START}echo http://localhost:\$(docker inspect --format='{{(index (index .NetworkSettings.Ports "8153/tcp") 0).HostPort}}' $HOSTNAME)${COLOR_END}
 
 If you're using docker through boot2docker, on a Mac, do this:
-${COLOR_START}echo http://\$(boot2docker ip):\$(docker inspect --format='{{(index (index .NetworkSettings.Ports "8153/tcp") 0).HostPort}}' $HOSTNAME)${COLOR_END}
+${COLOR_START}echo http://\$(docker-machine ip):\$(docker inspect --format='{{(index (index .NetworkSettings.Ports "8153/tcp") 0).HostPort}}' $HOSTNAME)${COLOR_END}
 
 That command will output the URL through which you should be able to access the Go Server.
 ${COLOR_START}----------------------------------------------------------${COLOR_END}


### PR DESCRIPTION
Hi,

I'm using docker version 1.12.0 on a mac and I noticed that the `boot2docker` command is not used anymore thus making the displayed server URL incorrect upon starting up the container so I updated the startup script with the `docker-machine` command to fix it.

I've also updated the domain in some files to reflect the latest domain change and also filled out the CLA form.

Thanks,