### PR TITLE
Remove the old environment variable usage.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+### Release 17.2.0 (February 21, 2017)
+
+- Download and use Java 8 for the gocd server and agent images.
+- Use the environment variable GO_SERVER_URL while connecting the gocd agent with the gocd server.
+
+#### Deprecations
+
+- As of release 17.2.0, the old environment variables `GO_SERVER` and `GO_SERVER_PORT` are deprecated. They will be removed in release 17.3.0. Users are encouraged to use the environment variable `GO_SERVER_URL`.
+

--- a/phusion/agent/go-agent-start.sh
+++ b/phusion/agent/go-agent-start.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-GO_SERVER=${GO_SERVER:-go-server}
-GO_SERVER_PORT=${GO_SERVER_PORT:-8154}
-GO_SERVER_URL=${GO_SERVER_URL:-https://${GO_SERVER}:${GO_SERVER_PORT}/go/}
+GO_SERVER_URL=${GO_SERVER_URL:-https://gocd-server:8154/go/}
 
 COLOR_START="[01;34m"
 COLOR_END="[00m"


### PR DESCRIPTION
* Change default name of the go server to be gocd-server for linked usage.
* Introduce changelog to keep track of changes across releases from now on.

Reason:
When linking a running go-server container with the go-agent, docker injects [certain environment variables](https://docs.docker.com/compose/link-env-deprecated/). By unfortunate coincidence, on docker hub, we mentioned -
`docker run -ti --link angry_feynman:go-server gocd/gocd-agent` 
This meant that one of the environment variables that was injected was `GO_SERVER_PORT` with value `tcp://<go server container ip>:8153`. This messed up the GO_SERVER_URL as `https://go-server:tcp://<go server container ip>:8153/go` because of https://github.com/gocd/gocd-docker/blob/master/phusion/agent/go-agent-start.sh#L5. 

The old environment variables are not longer required to connect to the go server.